### PR TITLE
リバーブ周りの整備

### DIFF
--- a/components/Instrument.vue
+++ b/components/Instrument.vue
@@ -3,7 +3,6 @@
     <v-btn @click="demo">demo</v-btn>
     <v-btn @click="demoMelody">demo melody</v-btn>
     <v-btn @click="stop">stop</v-btn>
-    <v-switch v-model="isReverb" label="isReverb"></v-switch>
   </div>
 </template>
 
@@ -88,15 +87,10 @@ export default Vue.extend({
       default: 1.0,
       type: Number
     },
-    isReverb: {
-      required: false,
-      type: Boolean,
-      default: false
-    },
     reverbPath: {
       required: false,
-      default: '',
-      type: String
+      default: null,
+      type: Object as Vue.PropType<string | null>
     }
   },
   data(): DataType {
@@ -116,6 +110,9 @@ export default Vue.extend({
     },
     encodedSfzParentPath(): string {
       return this.encodePath(this.parentDir(this.sfzPath))
+    },
+    isReverb() {
+      return this.reverbPath !== null
     }
   },
   watch: {
@@ -184,7 +181,7 @@ export default Vue.extend({
 
     async setReverb() {
       this.$emit('update:isLoading', false)
-
+      if (!this.reverbPath) return
       await fetch(this.reverbPath)
         .then((res) => res.text())
         .then((b64) => {

--- a/components/Player.vue
+++ b/components/Player.vue
@@ -11,8 +11,7 @@
           :is-playing="isPlaying"
           :is-ready.sync="isMelodyReady"
           :gain-value="gainValue"
-          :is-reverb="isReverb"
-          :reverb-path="reverbPath"
+          :reverb-path="null"
         />
       </v-col>
     </v-row>
@@ -121,6 +120,11 @@ export default Vue.extend({
       .then((res) => res.json())
       .then((res) => {
         this.$accessor.player.setInstruments(res)
+      })
+    fetch('/reverb/reverbs.json')
+      .then((res) => res.json())
+      .then((res) => {
+        this.$accessor.player.setReverbs(res)
       })
   },
   methods: {

--- a/components/Player.vue
+++ b/components/Player.vue
@@ -121,7 +121,7 @@ export default Vue.extend({
       .then((res) => {
         this.$accessor.player.setInstruments(res)
       })
-    fetch('/reverb/reverbs.json')
+    fetch('/reverbs/reverbs.json')
       .then((res) => res.json())
       .then((res) => {
         this.$accessor.player.setReverbs(res)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,8 +1,10 @@
 import colors from 'vuetify/es5/util/colors'
 import { Configuration } from '@nuxt/types'
 import { InstPlugin } from './tools/im/plugin'
+import { ReverbPlugin } from './tools/reverb/plugin'
 
 const instPlugin = new InstPlugin()
+const reverbPlugin = new ReverbPlugin()
 
 const config: Configuration = {
   mode: 'universal',
@@ -108,8 +110,8 @@ const config: Configuration = {
     transpile: [/typed-vuex/],
     extend(config, ctx) {
       if (ctx.isClient) {
-        if (config.plugins) config.plugins.push(instPlugin)
-        else config.plugins = [instPlugin]
+        if (config.plugins) config.plugins.push(instPlugin, reverbPlugin)
+        else config.plugins = [instPlugin, reverbPlugin]
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "nuxt-ts",
     "build": "nuxt-ts build",
     "inst": "ts-node -P ./tools/im/tsconfig.json ./tools/im/command.ts",
+    "reverb": "ts-node -P ./tools/reverb/tsconfig.json ./tools/reverb/command.ts",
     "generate": "nuxt-ts generate",
     "start": "nuxt-ts start",
     "lint": "eslint --ext .js,.ts,.vue --ignore-path .gitignore .",

--- a/store/player.ts
+++ b/store/player.ts
@@ -6,7 +6,8 @@ export const state = (): PlayerState => ({
   isPlaying: false,
   isReady: false,
   loadingProgress: 0,
-  instruments: []
+  instruments: [],
+  reverbs: []
 })
 
 export const mutations = mutationTree(state, {
@@ -24,6 +25,9 @@ export const mutations = mutationTree(state, {
   },
   SET_INSTRUMENTS(state: PlayerState, insts: string[]) {
     state.instruments = insts
+  },
+  SET_REVERBS(state: PlayerState, rvs: string[]) {
+    state.reverbs = rvs
   }
 })
 
@@ -47,6 +51,9 @@ export const actions = actionTree(
     },
     setInstruments({ commit }, insts: string[]) {
       commit('SET_INSTRUMENTS', insts)
+    },
+    setReverbs({ commit }, rvs: string[]) {
+      commit('SET_REVERBS', rvs)
     }
   }
 )

--- a/tools/im/index.ts
+++ b/tools/im/index.ts
@@ -1,9 +1,7 @@
 import path from 'path'
 import fs from 'fs-extra'
 import consola from 'consola'
-import axios from 'axios'
 import instrumentsList from '../../instruments.json'
-import reverbsList from '../../reverbs.json'
 import { downloadAndUnzip } from './downloader'
 import { transform } from './transform'
 
@@ -65,22 +63,4 @@ export async function main() {
     }
   )
   consola.info(`Instruments ready`)
-
-  consola.info('Preparing reverbs... ')
-
-  await mkdirIfNotExist('../../static/reverbs')
-  await Promise.all(
-    reverbsList.map(async (rev) => {
-      await axios.get(rev.url).then((res) => {
-        fs.writeFile(`static/reverbs/${rev.name}Base64`, res.data)
-      })
-    })
-  )
-
-  fs.writeFile(
-    `static/reverbs/reverbs.json`,
-    JSON.stringify(reverbsList.map((rev) => `reverbs/${rev.name}Base64`))
-  )
-
-  consola.info(`Reverbs ready`)
 }

--- a/tools/reverb/command.ts
+++ b/tools/reverb/command.ts
@@ -1,0 +1,3 @@
+import { main } from './index'
+
+main()

--- a/tools/reverb/index.ts
+++ b/tools/reverb/index.ts
@@ -19,7 +19,9 @@ export const main = async () => {
         await axios.get(rev.url).then((res) => {
           fs.writeFile(`static/reverbs/${rev.name}Base64`, res.data)
         })
-      } catch (e) {}
+      } catch (e) {
+        consola.error(e)
+      }
     })
   )
 
@@ -30,5 +32,3 @@ export const main = async () => {
 
   consola.info(`Reverbs ready`)
 }
-
-main()

--- a/tools/reverb/index.ts
+++ b/tools/reverb/index.ts
@@ -1,0 +1,34 @@
+import path from 'path'
+import consola from 'consola'
+import axios from 'axios'
+import fs from 'fs-extra'
+import reverbsList from '../../reverbs.json'
+
+export const main = async () => {
+  async function mkdirIfNotExist(p: string) {
+    if (!fs.existsSync(path.resolve(__dirname, p)))
+      await fs.mkdir(path.resolve(__dirname, p))
+  }
+
+  consola.info('Preparing reverbs... ')
+
+  await mkdirIfNotExist('../../static/reverbs')
+  await Promise.all(
+    reverbsList.map(async (rev) => {
+      try {
+        await axios.get(rev.url).then((res) => {
+          fs.writeFile(`static/reverbs/${rev.name}Base64`, res.data)
+        })
+      } catch (e) {}
+    })
+  )
+
+  fs.writeFile(
+    `static/reverbs/reverbs.json`,
+    JSON.stringify(reverbsList.map((rev) => `reverbs/${rev.name}Base64`))
+  )
+
+  consola.info(`Reverbs ready`)
+}
+
+main()

--- a/tools/reverb/plugin.ts
+++ b/tools/reverb/plugin.ts
@@ -1,0 +1,13 @@
+import { Plugin, Compiler } from 'webpack'
+import fs from 'fs-extra'
+import { main } from './index'
+let ran = false
+export class ReverbPlugin implements Plugin {
+  apply(compiler: Compiler) {
+    compiler.hooks.beforeCompile.tapPromise('ReverbPlugin', async () => {
+      if (ran) return
+      ran = true
+      if (!fs.existsSync('static/reverbs')) await main()
+    })
+  }
+}

--- a/tools/reverb/tsconfig.json
+++ b/tools/reverb/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "commonjs",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "lib": [
+      "esnext",
+      "esnext.asynciterable"
+    ],
+  }
+}

--- a/types/player.d.ts
+++ b/types/player.d.ts
@@ -4,4 +4,5 @@ export interface PlayerState {
   isReady: boolean
   loadingProgress: number
   instruments: string[]
+  reverbs: string[]
 }


### PR DESCRIPTION
- リバーブダウンロードの処理を別に分けた。
- isReverbはpropsからは消して reverb-pathに指定があったら有効になるようにした
（そうしないとリバーブが必要なくても読み込みが発生したりするので）