### PR TITLE
音声のプレビュー機能の繋ぎこみ

### DIFF
--- a/components/chordBlockList.vue
+++ b/components/chordBlockList.vue
@@ -45,7 +45,7 @@ export default Vue.extend({
   },
   data() {
     return {
-      selection: 0
+      selection: null
     }
   },
   computed: {
@@ -57,6 +57,17 @@ export default Vue.extend({
         acc[cur.category].push(cur)
         return acc
       }, {} as BlockGroup)
+    }
+  },
+  watch: {
+    async selection(newIndex: number) {
+      if (newIndex === undefined) return
+      this.$accessor.player.stopPresetPreview()
+      await this.$nextTick()
+      this.$accessor.player.playPresetPreview({
+        part: 'melody',
+        name: 'メロ1'
+      })
     }
   }
 })

--- a/components/melodyBlockList.vue
+++ b/components/melodyBlockList.vue
@@ -45,7 +45,7 @@ export default Vue.extend({
   },
   data() {
     return {
-      selection: 0
+      selection: null
     }
   },
   computed: {
@@ -57,6 +57,17 @@ export default Vue.extend({
         acc[cur.category].push(cur)
         return acc
       }, {} as BlockGroup)
+    }
+  },
+  watch: {
+    async selection(newIndex: number) {
+      if (newIndex === undefined) return
+      this.$accessor.player.stopPresetPreview()
+      await this.$nextTick()
+      this.$accessor.player.playPresetPreview({
+        part: 'melody',
+        name: 'メロ1'
+      })
     }
   }
 })

--- a/components/rhythmBlockList.vue
+++ b/components/rhythmBlockList.vue
@@ -45,7 +45,7 @@ export default Vue.extend({
   },
   data() {
     return {
-      selection: 0
+      selection: null
     }
   },
   computed: {

--- a/components/rhythmBlockList.vue
+++ b/components/rhythmBlockList.vue
@@ -58,6 +58,17 @@ export default Vue.extend({
         return acc
       }, {} as BlockGroup)
     }
+  },
+  watch: {
+    async selection(newIndex: number) {
+      if (newIndex === undefined) return
+      this.$accessor.player.stopPresetPreview()
+      await this.$nextTick()
+      this.$accessor.player.playPresetPreview({
+        part: 'melody',
+        name: 'メロ1'
+      })
+    }
   }
 })
 </script>


### PR DESCRIPTION
# 変更点
- モーダル上でブロックをタップするとプレビューが再生される（まだプリセットが整いきってないとのことで，今のところはmelodyのメロ1が固定で再生されるようになってる）．

# その他
- モーダル上のindex: 0のブロックを初期選択状態にしていたが，uiux上好ましくないため，初期選択をnullに修正した．
- 選択状態のブロックをタップしても選択解除するだけで，プレビューは再生されないように修正した．