### PR TITLE
プロジェクト名を入力可能 & 譜面幅をレスポンシブ化

### DIFF
--- a/components/ScorePartEditor.vue
+++ b/components/ScorePartEditor.vue
@@ -82,6 +82,10 @@ export default Vue.extend({
     showsDialog: {
       required: true,
       type: Boolean
+    },
+    blockAreaLength: {
+      type: Number,
+      required: true
     }
   },
   data() {
@@ -93,6 +97,7 @@ export default Vue.extend({
   },
   computed: {
     dragOptions() {
+      console.log(this.$accessor.music.rhythmBlocks)
       return {
         animation: 300,
         disabled: false
@@ -101,7 +106,24 @@ export default Vue.extend({
     maxLength(): number {
       // 各partにおけるdurationの合計の最大値 / 2 + 1 (追加ボタン分)
       // TODO: fetch from store
-      return Math.floor(13 / 2) + 1
+      const RhythmLength: number = this.$accessor.music.rhythmBlocks.reduce(
+        (p: number, x: Block) => p + x.duration,
+        0
+      )
+      const ChordLength: number = this.$accessor.music.chordBlocks.reduce(
+        (p: number, x: Block) => p + x.duration,
+        0
+      )
+      const MelodyLength: number = this.$accessor.music.melodyBlocks.reduce(
+        (p: number, x: Block) => p + x.duration,
+        0
+      )
+      const maxLength: number = Math.max(
+        RhythmLength,
+        ChordLength,
+        MelodyLength
+      )
+      return Math.floor(maxLength / 2) + 1
     },
     partTitle(): string {
       return {

--- a/components/chordBlockList.vue
+++ b/components/chordBlockList.vue
@@ -31,7 +31,7 @@
       </v-card-actions>
     </v-card>
 
-    <v-dialog v-model="attention">
+    <v-dialog v-model="attention" max-width="500">
       <v-card>
         <v-card-actions>
           <v-card-title>注意</v-card-title>

--- a/components/chordBlockList.vue
+++ b/components/chordBlockList.vue
@@ -31,11 +31,20 @@
       </v-card-actions>
     </v-card>
 
-    <v-dialog v-model="attention" max-width="500">
+    <v-dialog v-model="attention" max-width="1000">
       <v-card>
-        <v-card-actions>
-          <v-card-title>注意</v-card-title>
-          <v-card-text>ブロックを選択しろや</v-card-text>
+        <v-card-title class="attention-modal-title"
+          ><span class="material-icons">warning</span></v-card-title
+        >
+        <v-card-text class="attention-modal-text">
+          ブロック選べや．ちょっと考えれば分かるやろ．
+        </v-card-text>
+
+        <v-card-actions class="attention-modal-btn">
+          <v-spacer></v-spacer>
+          <v-btn color="orange darken-1" text @click="attention = false">
+            Agree
+          </v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -140,5 +149,22 @@ div#component-frame {
 .v-divider {
   background-color: $-gray-500;
   margin-bottom: 5px;
+}
+.attention-modal-title {
+  background-color: $-gray-700;
+  .material-icons {
+    color: $-primary-500;
+    font-size: 30px;
+  }
+}
+.attention-modal-text.v-card__text {
+  background-color: $-gray-700;
+  color: $-gray-50;
+  text-align: center;
+  margin: 0;
+  padding: 30px;
+}
+.attention-modal-btn {
+  background-color: $-gray-700;
 }
 </style>

--- a/components/melodyBlockList.vue
+++ b/components/melodyBlockList.vue
@@ -31,7 +31,7 @@
       </v-card-actions>
     </v-card>
 
-    <v-dialog v-model="attention">
+    <v-dialog v-model="attention" max-width="500">
       <v-card>
         <v-card-actions>
           <v-card-title>注意</v-card-title>

--- a/components/melodyBlockList.vue
+++ b/components/melodyBlockList.vue
@@ -31,11 +31,20 @@
       </v-card-actions>
     </v-card>
 
-    <v-dialog v-model="attention" max-width="500">
+    <v-dialog v-model="attention" max-width="1000">
       <v-card>
-        <v-card-actions>
-          <v-card-title>注意</v-card-title>
-          <v-card-text>ブロックを選択しろや</v-card-text>
+        <v-card-title class="attention-modal-title"
+          ><span class="material-icons">warning</span></v-card-title
+        >
+        <v-card-text class="attention-modal-text">
+          ちゃんとブロック選択しいや
+        </v-card-text>
+
+        <v-card-actions class="attention-modal-btn">
+          <v-spacer></v-spacer>
+          <v-btn color="orange darken-1" text @click="attention = false">
+            Agree
+          </v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -140,5 +149,22 @@ div#component-frame {
 .v-divider {
   background-color: $-gray-500;
   margin-bottom: 5px;
+}
+.attention-modal-title {
+  background-color: $-gray-700;
+  .material-icons {
+    color: $-primary-500;
+    font-size: 30px;
+  }
+}
+.attention-modal-text.v-card__text {
+  background-color: $-gray-700;
+  color: $-gray-50;
+  text-align: center;
+  margin: 0;
+  padding: 30px;
+}
+.attention-modal-btn {
+  background-color: $-gray-700;
 }
 </style>

--- a/components/musicalScore.vue
+++ b/components/musicalScore.vue
@@ -2,8 +2,12 @@
   <div id="component-frame">
     <v-container>
       <div class="score-header">
-        <h2 class="score-header-title">{{ scoreTitle }}</h2>
-        <div class="score-header-creator">{{ scoreComposer }}</div>
+        <h2 class="score-header-title">
+          <input v-model="scoreTitle" placeholder="Add Music Name" />
+        </h2>
+        <div class="score-header-creator">
+          <input v-model="scoreComposer" placeholder="Add Your Name" />
+        </div>
       </div>
 
       <div class="score-container">
@@ -52,11 +56,21 @@ export default Vue.extend({
     }
   },
   computed: {
-    scoreTitle(): string {
-      return this.$accessor.music.title
+    scoreTitle: {
+      get() {
+        return this.$accessor.music.title
+      },
+      set(input: string) {
+        this.$accessor.music.setTitle(input)
+      }
     },
-    scoreComposer(): string {
-      return this.$accessor.music.composer
+    scoreComposer: {
+      get() {
+        return this.$accessor.music.composer
+      },
+      set(input) {
+        this.$accessor.music.setComposer(input)
+      }
     }
   },
   methods: {

--- a/components/musicalScore.vue
+++ b/components/musicalScore.vue
@@ -14,13 +14,13 @@
         <div class="seek-bar" />
 
         <div class="open-blocklist">
-          <v-dialog v-model="rhythmDialog">
+          <v-dialog v-model="rhythmDialog" max-width="800">
             <RhythmBlockList @clickAddBlock="closeDialog" />
           </v-dialog>
-          <v-dialog v-model="chordDialog">
+          <v-dialog v-model="chordDialog" max-width="800">
             <ChordBlockList @clickAddBlock="closeDialog" />
           </v-dialog>
-          <v-dialog v-model="melodyDialog">
+          <v-dialog v-model="melodyDialog" max-width="800">
             <MelodyBlockList @clickAddBlock="closeDialog" />
           </v-dialog>
         </div>

--- a/components/musicalScore.vue
+++ b/components/musicalScore.vue
@@ -68,7 +68,7 @@ export default Vue.extend({
       get() {
         return this.$accessor.music.composer
       },
-      set(input) {
+      set(input: string) {
         this.$accessor.music.setComposer(input)
       }
     }

--- a/components/rhythmBlockList.vue
+++ b/components/rhythmBlockList.vue
@@ -31,7 +31,7 @@
       </v-card-actions>
     </v-card>
 
-    <v-dialog v-model="attention">
+    <v-dialog v-model="attention" max-width="500">
       <v-card>
         <v-card-actions>
           <v-card-title>注意</v-card-title>

--- a/components/rhythmBlockList.vue
+++ b/components/rhythmBlockList.vue
@@ -39,9 +39,18 @@
 
     <v-dialog v-model="attention">
       <v-card>
-        <v-card-actions>
-          <v-card-title>注意</v-card-title>
-          <v-card-text>ブロックを選択しろや</v-card-text>
+        <v-card-title class="attention-modal-title"
+          ><span class="material-icons">warning</span></v-card-title
+        >
+        <v-card-text class="attention-modal-text">
+          ブロックを選択しろや
+        </v-card-text>
+
+        <v-card-actions class="attention-modal-btn">
+          <v-spacer></v-spacer>
+          <v-btn color="orange darken-1" text @click="attention = false">
+            Agree
+          </v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -152,5 +161,22 @@ div#component-frame {
 .v-divider {
   background-color: $-gray-500;
   margin-bottom: 5px;
+}
+.attention-modal-title {
+  background-color: $-gray-700;
+  .material-icons {
+    color: $-primary-500;
+    font-size: 30px;
+  }
+}
+.attention-modal-text.v-card__text {
+  background-color: $-gray-700;
+  color: $-gray-50;
+  text-align: center;
+  margin: 0;
+  padding: 30px;
+}
+.attention-modal-btn {
+  background-color: $-gray-700;
 }
 </style>

--- a/components/rhythmBlockList.vue
+++ b/components/rhythmBlockList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="component-frame">
+  <div id="rhythm-block-list">
     <v-card class="mx-auto">
       <v-card-title>
         <p>リズムの追加</p>
@@ -25,13 +25,19 @@
       </v-chip-group>
 
       <v-card-actions>
-        <v-btn block class="white--text" color="#F96500" @click="addBlock">
+        <v-btn
+          id="rhythm-block-list-add"
+          block
+          class="white--text"
+          color="#F96500"
+          @click="addBlock"
+        >
           Add to Score
         </v-btn>
       </v-card-actions>
     </v-card>
 
-    <v-dialog v-model="attention" max-width="500">
+    <v-dialog v-model="attention">
       <v-card>
         <v-card-actions>
           <v-card-title>注意</v-card-title>
@@ -62,13 +68,16 @@ export default Vue.extend({
   },
   computed: {
     rhythmBlocks(): BlockGroup {
-      return this.$accessor.music.rhythmTemplates.reduce((acc, cur) => {
-        if (!acc[cur.category]) {
-          acc[cur.category] = []
-        }
-        acc[cur.category].push(cur)
-        return acc
-      }, {} as BlockGroup)
+      return this.$accessor.music.rhythmTemplates.reduce(
+        (acc: BlockGroup, cur: Block) => {
+          if (!acc[cur.category]) {
+            acc[cur.category] = []
+          }
+          acc[cur.category].push(cur)
+          return acc
+        },
+        {} as BlockGroup
+      )
     }
   },
   watch: {
@@ -112,6 +121,9 @@ export default Vue.extend({
   }
 }
 div#component-frame {
+  height: 100%;
+}
+#rhythm-block-list {
   height: 100%;
 }
 .v-card__text {

--- a/components/rhythmBlockList.vue
+++ b/components/rhythmBlockList.vue
@@ -37,13 +37,13 @@
       </v-card-actions>
     </v-card>
 
-    <v-dialog v-model="attention">
+    <v-dialog v-model="attention" max-width="1000">
       <v-card>
         <v-card-title class="attention-modal-title"
           ><span class="material-icons">warning</span></v-card-title
         >
         <v-card-text class="attention-modal-text">
-          ブロックを選択しろや
+          ブロックを選択してください．クソが．
         </v-card-text>
 
         <v-card-actions class="attention-modal-btn">

--- a/store/music.ts
+++ b/store/music.ts
@@ -195,6 +195,12 @@ export const mutations = mutationTree(state, {
    */
   SET_MELODY_INSTRUMENT(state: MusicState, melodyInst: string) {
     state.melody.instrument = melodyInst
+  },
+  SET_TITLE(state: MusicState, input: string) {
+    state.title = input
+  },
+  SET_COMPOSER(state: MusicState, input: string) {
+    state.composer = input
   }
 })
 
@@ -332,6 +338,12 @@ export const actions = actionTree(
      */
     setMelodyInstrument({ commit }, MelodyInst: string) {
       commit('SET_MELODY_INSTRUMENT', MelodyInst)
+    },
+    setTitle({ commit }, Input: string) {
+      commit('SET_TITLE', Input)
+    },
+    setComposer({ commit }, Input: string) {
+      commit('SET_COMPOSER', Input)
     }
   }
 )


### PR DESCRIPTION
# 変更点
- **曲名**と**作曲者名**を入力可能に実装
- `ScorePartEditor`コンポネントで，追加したブロックに応じて譜面の幅が増加する機能の実装