### PR TITLE
ブロック名変更あきらめます

### DIFF
--- a/components/BlockItem.vue
+++ b/components/BlockItem.vue
@@ -35,7 +35,7 @@ export default Vue.extend({
   computed: {
     // 半小節を1つ分の長さに
     blockLength(): number {
-      return this.block.duration / 2
+      return this.block.duration / 4
     }
   }
 })

--- a/components/musicalScore.vue
+++ b/components/musicalScore.vue
@@ -37,20 +37,12 @@
 
         <div class="seek-bar" :style="seekBarStyle" />
       </div>
-
-      <transition name="trash">
-        <div v-if="!isPlaying && trashPart" class="score-trash-wrapper">
-          <draggable class="score-draggable-trash" :group="trashPart" />
-          <v-icon class="icon">fa-trash</v-icon>
-        </div>
-      </transition>
     </v-container>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
-import draggable from 'vuedraggable'
 import ScorePartEditor from '@/components/ScorePartEditor.vue'
 import { Block, ScorePart } from '@/types/music'
 
@@ -61,7 +53,6 @@ type DataType = {
 
 export default Vue.extend({
   components: {
-    draggable,
     ScorePartEditor
   },
   data(): DataType {
@@ -193,44 +184,6 @@ div#component-frame {
     background-color: red;
     opacity: 0.5;
   }
-}
-
-.score-trash-wrapper {
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 5rem;
-  width: 100%;
-
-  .score-draggable-trash {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    background-color: $-gray-500;
-    border-radius: 50%;
-    height: 4rem;
-    width: 4rem;
-    opacity: 0.5;
-  }
-
-  .icon {
-    position: absolute;
-    color: $-gray-50;
-  }
-}
-
-.trash-enter-active,
-.trash-leave-active {
-  transform: translateY(0) translateZ(0);
-  transition: transform 100ms linear 100ms;
-}
-
-.trash-enter,
-.trash-leave-to {
-  transform: translateY(10vh) translateZ(0);
 }
 
 @include pc {

--- a/components/musicalScore.vue
+++ b/components/musicalScore.vue
@@ -94,7 +94,7 @@ export default Vue.extend({
       return Math.max(RhythmDuration, ChordDuration, MelodyDuration)
     },
     scoreLength(): number {
-      return Math.floor(this.musicDuration / 2)
+      return Math.floor(this.musicDuration / 4)
     },
     seekBarStyle(): Object {
       const style = {

--- a/components/rhythmModal.vue
+++ b/components/rhythmModal.vue
@@ -2,15 +2,15 @@
   <div id="component-frame">
     <v-card>
       <!-- 編集画面上部 -->
-      <v-card-title class="top-area">
-        リズム編集画面
+      <v-card-title class="top-area rounded-0">
+        <h2>{{ blockName }}</h2>
         <v-btn icon dark @click="dialog">
           <v-icon>mdi-close</v-icon>
         </v-btn>
       </v-card-title>
 
       <!-- 編集エリア -->
-      <v-card class="edit-area">
+      <v-card class="edit-area rounded-0">
         <rhythmEditor
           v-for="i in key_inst"
           :key="i.drum_key"
@@ -24,7 +24,7 @@
       <!-- 再生エリア -->
       <v-card-title class="play-area">
         <v-btn icon dark @click="playPreview()">
-          <v-icon color="#F96500" large>play_arrow</v-icon>
+          <v-icon size="350%" color="#F96500">play_arrow</v-icon>
         </v-btn>
       </v-card-title>
     </v-card>
@@ -124,6 +124,8 @@ div#component-frame {
 .top-area {
   font-size: 80%;
   background-color: $-gray-900;
+  display: flex;
+  justify-content: space-between;
 }
 
 .play-area {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,8 +1,15 @@
 <template>
   <div id="component-frame">
     <div id="musical-score-wrapper">
-      <musical-score />
+      <musical-score :trash-part.sync="trashPart" />
     </div>
+
+    <transition name="trash">
+      <div v-if="!isPlaying && trashPart" class="score-trash-wrapper">
+        <draggable class="score-draggable-trash" :group="trashPart" />
+        <v-icon class="icon">fa-trash</v-icon>
+      </div>
+    </transition>
 
     <div id="operation-area-wrapper">
       <operation-area />
@@ -12,20 +19,24 @@
 </template>
 
 <script lang="ts">
+import Vue from 'vue'
 import { Context } from '@nuxt/types'
+import draggable from 'vuedraggable'
 
 import MusicalScore from '@/components/musicalScore.vue'
 import OperationArea from '@/components/operationArea.vue'
 import Player from '@/components/Player.vue'
 import { firebaseAuth, firestoreAccessor } from '@/plugins/firebase'
-import { Music } from '@/types/music'
+import { Music, ScorePart } from '@/types/music'
 
 type DataType = {
   dialog: boolean
+  trashPart: ScorePart | null
 }
 
-export default {
+export default Vue.extend({
   components: {
+    draggable,
     MusicalScore,
     OperationArea,
     Player
@@ -63,13 +74,16 @@ export default {
   },
   data(): DataType {
     return {
-      dialog: false
+      dialog: false,
+      trashPart: null
     }
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>
+$operation-area-height: 10vh;
+
 #component-frame {
   background-color: $-gray-800;
   height: 100vh;
@@ -96,10 +110,48 @@ export default {
 }
 
 #operation-area-wrapper {
-  height: 10vh;
+  height: $operation-area-height;
   width: 100vw;
   position: fixed;
   bottom: 0;
+}
+
+.score-trash-wrapper {
+  position: absolute;
+  left: 0;
+  bottom: $operation-area-height;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 5rem;
+  width: 100%;
+
+  .score-draggable-trash {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: $-gray-500;
+    border-radius: 50%;
+    height: 4rem;
+    width: 4rem;
+    opacity: 0.5;
+  }
+
+  .icon {
+    position: absolute;
+    color: $-gray-50;
+  }
+}
+
+.trash-enter-active,
+.trash-leave-active {
+  transform: translateY(0) translateZ(0);
+  transition: transform 100ms linear 100ms;
+}
+
+.trash-enter,
+.trash-leave-to {
+  transform: translateY(10vh) translateZ(0);
 }
 
 @include pc {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,14 +4,14 @@
       <musical-score :trash-part.sync="trashPart" />
     </div>
 
-    <transition name="trash">
-      <div v-if="!isPlaying && trashPart" class="score-trash-wrapper">
-        <draggable class="score-draggable-trash" :group="trashPart" />
-        <v-icon class="icon">fa-trash</v-icon>
-      </div>
-    </transition>
-
     <div id="operation-area-wrapper">
+      <transition name="trash">
+        <div v-if="!isPlaying && trashPart" class="score-trash-wrapper">
+          <draggable class="score-draggable-trash" :group="trashPart" />
+          <v-icon class="icon">fa-trash</v-icon>
+        </div>
+      </transition>
+
       <operation-area />
     </div>
     <player />
@@ -88,11 +88,51 @@ $operation-area-height: 10vh;
   background-color: $-gray-800;
   height: 100vh;
   color: $-gray-500;
+  position: relative;
+}
+
+.score-header {
+  height: $operation-area-height;
+  width: 100%;
+  box-sizing: border-box;
+  position: fixed;
+  top: 0;
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: $-gray-900;
+
+  .score-header-title {
+    margin-bottom: 0.2rem;
+    input {
+      color: $-gray-50 !important;
+    }
+  }
+  .score-header-creator {
+    input {
+      color: $-gray-100;
+    }
+  }
+
+  .mode-switch-wrapper {
+    text-align: center;
+
+    .mode-switch-label {
+      font-size: 16px;
+      font-weight: bold;
+      color: $-gray-100;
+    }
+
+    .mode-switch {
+      margin: 0 0 -1rem 0;
+    }
+  }
 }
 
 #musical-score-wrapper {
-  height: calc(100% - 10vh);
-  margin-bottom: 3vh;
+  height: calc(100% - $operation-area-height * 2);
+  margin: $operation-area-height 0;
   overflow: scroll;
   // for IE, Edge
   -ms-overflow-style: none;
@@ -111,7 +151,7 @@ $operation-area-height: 10vh;
 
 #operation-area-wrapper {
   height: $operation-area-height;
-  width: 100vw;
+  width: 100%;
   position: fixed;
   bottom: 0;
 }


### PR DESCRIPTION
ブロック名を変更する際, storeからcomputedで呼び出しており, ブロックリストと楽譜のblockNamesで不整合が起きて落ちる.  
これを対処するにはblocksとblockNamesを同時に変更する or 変更の際にcomputedの更新を止めることが考えられるが, どちらも現実的じゃない (よね...?)

もう一つの対処として, 編集中のblockはmodalで保持しておいて, modalを閉じるときにstateを更新する方法があるが, player側がプレビューするときにstateを参照しており, stateを直接変更しない方法はプレビューが追従されない問題が発生する

ただ, これはplayer側がmusicのstateに依存しているのも問題だと思われる  
本来playerは渡されたsoundsを基に再生するだけの存在であるべきで, musicのstateから引っ張ってきて整形するのは別のコンポーネントが行うべきことなのではないか

ただ変更範囲がデカいので発表2週間前とかにやるべきことではない

てことであきらめます 🙇 